### PR TITLE
Fix #153: Added 30 timeout readUntil in olimex sendKey

### DIFF
--- a/framework/core/remoteControllerModules/olimex.py
+++ b/framework/core/remoteControllerModules/olimex.py
@@ -48,7 +48,7 @@ class remoteOlimex():
         self.telnet.read_very_eager()
         if False==self.telnet.write(cmd):
             return False
-        if not "(OK)" in self.telnet.read_until("(OK)"):
+        if not "(OK)" in self.telnet.read_until("(OK)", 20):
             return False
         self.telnet.disconnect()
         return True


### PR DESCRIPTION
Increased the timeout in the readUntil in the sendKey method of the olimex remote control module to prevent timeout when key send is successful