### PR TITLE
Fix the number of retries before reading input from CEC Adapter

### DIFF
--- a/framework/core/hdmicecModules/remoteCECClient.py
+++ b/framework/core/hdmicecModules/remoteCECClient.py
@@ -80,7 +80,7 @@ class RemoteCECClient(CECInterface):
 
     def listDevices(self) -> list:
         self._console.write(f'scan')
-        output = self._stream.readUntil('currently active source',30)
+        output = self._stream.readUntil('currently active source',90)
         devices = []
         if len(output) > 0:
             output = '\n'.join(output)


### PR DESCRIPTION
Problem:
Output from CEC Adaptor is not scanned properly thus creating problem in listing devices.

Solution:
Increase the retry count