### PR TITLE
Fix #188 - Corrected requirements for python3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ anyio==4.3.0
 async-timeout==4.0.3
 asyncclick==8.1.7.2
 asyncio==3.4.3
+asyncstdlib==3.13.1
 attrs==23.2.0
 bcrypt==4.1.2
 beautifulsoup4==4.12.3
@@ -16,9 +17,10 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 cryptography==42.0.5
 decorator==5.1.1
-defusedxml==3.13.1
+defusedxml==0.7.1
 denonavr==1.1.2
 Deprecated==1.2.14
+exceptiongroup==1.3.0
 fabric==3.2.2
 frozenlist==1.4.1
 ftfy==6.3.1
@@ -61,7 +63,7 @@ trio==0.25.0
 trio-websocket==0.11.1
 typing_extensions==4.10.0
 urllib3==1.26.18
-wcwidth==0.2.13
+wcwidth==0.2.14
 wrapt==1.16.0
 wsproto==1.2.0
 yarl==1.9.4


### PR DESCRIPTION
The previous version of this file was created by doing a `pip freeze` from a python 3.11 environment. Some of the dependency packages in there were python 3.11 specific. I have recreated the file with a python 3.10 environment to correct this.


closes #188 