### PR TITLE
Fix virtual cec

### DIFF
--- a/framework/core/hdmicecModules/virtualCECController.py
+++ b/framework/core/hdmicecModules/virtualCECController.py
@@ -94,6 +94,7 @@ class virtualCECController(CECInterface):
         except Exception as e:
             self._log.critical(f"Failed to load device configuration: {e}")
             raise
+        self.start()
 
     def loadCecDeviceNetworkConfiguration(self, configString: str):
         """


### PR DESCRIPTION
Virtual Cec controller is not calling start(). similar to remoteCECController.
This PR adds start to virtual CEC controller.